### PR TITLE
Example of Partial Binding

### DIFF
--- a/Form.php
+++ b/Form.php
@@ -487,12 +487,6 @@ class Form implements \IteratorAggregate, FormInterface
                 throw new UnexpectedTypeException($clientData, 'array');
             }
 
-            foreach ($this->children as $name => $child) {
-                if (!isset($clientData[$name])) {
-                    $clientData[$name] = null;
-                }
-            }
-
             foreach ($clientData as $name => $value) {
                 if ($this->has($name)) {
                     $this->children[$name]->bind($value);


### PR DESCRIPTION
_I know this is a read-only repository, but this is an easy way for you to see what modifications I needed without creating more noise on the Symfony repo_

@fabpot Here's the fix I previously advocated and an example...

My company does lead generation and are launching in the next week or so with our Symfony2-based flagship product (complete rewrite from Zend Framework 1.x).

We have several landing pages for our traffic where the user says "I'm interested in X service from Y company", clicks a link, and is taken to our application.

In the application, we have code similar to the following:

```
$lead = new ServiceLead;

// Default values for this lead
$lead->setPublisher($publisher);    // The originating site
$lead->setSessionId($this->get('session')->getId());

// Create the form associated with the lead
$form = $this->get('form.factory')->create(new LeadType);
$form->setData($lead);

// Bind any data the landing-page may have already requested from the user:
// ex. ?company=12&product=47&service_date=2011-07-04&first_name=Fabien
// This MUST be a partial bind, as affiliates & publisher sites can pre-fill form elements
// via the query string.
$form->bindRequest($this->get('request'));

// Behind the scenes, an event subscriber may even pre-fill your address based
// on your IP address
    ...
    if ($form->get('ip')->isValid()) {
        ...
        $form->bind(array('city' => $city, 'code' => $code, ... ));
        ...
    }
    ...

// Usual flow here...
if ('POST' === $this->get('request')->getMethod()) {
    ...
}
```

**I'm no longer advocating a PR or modification to the Form component**.  This is just so you can see how we are using forms in the wild to improve on what we had before with Zend Framework.

Thanks.
