### PR TITLE
Use translation mechanism to replace the form name in the error message

### DIFF
--- a/Extension/Core/Validator/DefaultValidator.php
+++ b/Extension/Core/Validator/DefaultValidator.php
@@ -20,7 +20,7 @@ class DefaultValidator implements FormValidatorInterface
     public function validate(FormInterface $form)
     {
         if (!$form->isSynchronized()) {
-            $form->addError(new FormError(sprintf('The value for "%s" is invalid', $form->getName())));
+            $form->addError(new FormError('The value for "%name%" is invalid', array('%name%' => $form->getName())));
         }
 
         if (count($form->getExtraData()) > 0) {


### PR DESCRIPTION
Use the translation mechanism to replace the form name in the error message instead of sprintf. Like this you can define one single translation in you translations instead of having to have an entry for every single form field.
