### PR TITLE
Fixed typos in the @throws PHPDoc exception names

### DIFF
--- a/CallbackTransformer.php
+++ b/CallbackTransformer.php
@@ -44,8 +44,8 @@ class CallbackTransformer implements DataTransformerInterface
      *
      * @return mixed                     The value in the transformed representation
      *
-     * @throws UnexpectedTypeException   when the argument is not a string
-     * @throws DataTransformerException  when the transformation fails
+     * @throws UnexpectedTypeException          when the argument is not a string
+     * @throws TransformationFailedException    when the transformation fails
      */
     public function transform($data)
     {
@@ -60,8 +60,8 @@ class CallbackTransformer implements DataTransformerInterface
      *
      * @return mixed                     The value in the original representation
      *
-     * @throws UnexpectedTypeException   when the argument is not of the expected type
-     * @throws DataTransformerException  when the transformation fails
+     * @throws UnexpectedTypeException          when the argument is not of the expected type
+     * @throws TransformationFailedException    when the transformation fails
      */
     public function reverseTransform($data)
     {

--- a/DataTransformerInterface.php
+++ b/DataTransformerInterface.php
@@ -43,8 +43,8 @@ interface DataTransformerInterface
      *
      * @return mixed                     The value in the transformed representation
      *
-     * @throws UnexpectedTypeException   when the argument is not a string
-     * @throws DataTransformerException  when the transformation fails
+     * @throws UnexpectedTypeException          when the argument is not a string
+     * @throws TransformationFailedException    when the transformation fails
      */
     function transform($value);
 
@@ -70,8 +70,8 @@ interface DataTransformerInterface
      *
      * @return mixed                     The value in the original representation
      *
-     * @throws UnexpectedTypeException   when the argument is not of the expected type
-     * @throws DataTransformerException  when the transformation fails
+     * @throws UnexpectedTypeException          when the argument is not of the expected type
+     * @throws TransformationFailedException    when the transformation fails
      */
     function reverseTransform($value);
 }


### PR DESCRIPTION
This morning I used the PHPDoc comments to learn how to use DataTransformer and i noticied that the exception name was not up-to-date 
