### PR TITLE
Add custom type in test case

### DIFF
--- a/Tests/FormIntegrationTestCase.php
+++ b/Tests/FormIntegrationTestCase.php
@@ -31,10 +31,16 @@ abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
 
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
+            ->addTypes($this->getTypes())
             ->getFormFactory();
     }
 
     protected function getExtensions()
+    {
+        return array();
+    }
+    
+    protected function getTypes()
     {
         return array();
     }


### PR DESCRIPTION
If we have to load some custom type, actually we only can use addType() from $factory that send a E_DEPRECATED error and phpunit failed! I added method addTypes() to allow dev to overload this method to add their own types like addExtension() method.
