### PR TITLE
Update FormInterface::add doc block

### DIFF
--- a/FormInterface.php
+++ b/FormInterface.php
@@ -39,7 +39,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function getParent();
 
     /**
-     * Adds a child to the form.
+     * Add or replace a child to the form.
      *
      * @param FormInterface|string|integer $child   The FormInterface instance or the name of the child.
      * @param string|null                  $type    The child's type, if a name was passed.


### PR DESCRIPTION
When replacing a child form from within a form event, it's not obvious that you have to use the 'add' method. Hopefully this will save somebody a google search.
