### PR TITLE
extraData error

### DIFF
--- a/Form.php
+++ b/Form.php
@@ -556,7 +556,7 @@ class Form implements \IteratorAggregate, FormInterface
                 }
 
                 foreach ($this->children as $name => $child) {
-                    if (isset($submittedData[$name]) || $clearMissing) {
+                    if (array_key_exists($name, $submittedData) || $clearMissing) {
                         $child->submit(isset($submittedData[$name]) ? $submittedData[$name] : null, $clearMissing);
                         unset($submittedData[$name]);
 


### PR DESCRIPTION
isset() is not correct here: If you submit a form with the value NULL (for example: firstname: null) the Form class handles firstname as extraData and the form has errors although firstname is defined in a formtype
