### PR TITLE
[Form][DX] Added getOnlyGlobalErrors() and getAllErrors() as proxy methods for getErrors()

### DIFF
--- a/Form.php
+++ b/Form.php
@@ -802,6 +802,22 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
 
     /**
      * {@inheritdoc}
+     */
+    public function getAllErrors()
+    {
+        return $this->getErrors(true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOnlyGlobalErrors()
+    {
+        return $this->getErrors();
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @return $this
      */

--- a/FormInterface.php
+++ b/FormInterface.php
@@ -104,6 +104,22 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function getErrors($deep = false, $flatten = true);
 
     /**
+     * Returns the list of the current form and all child forms.
+     *
+     * @return FormErrorIterator An iterator over the {@link FormError}
+     *                           instances that where added to the form and the child forms.
+     */
+    public function getAllErrors();
+
+    /**
+     * Returns the list of this form only - without child errors.
+     *
+     * @return FormErrorIterator an iterator over the {@link FormError}
+     *                           instances that where added to the top level of this form.
+     */
+    public function getOnlyGlobalErrors();
+
+    /**
      * Updates the form with default data.
      *
      * @param mixed $modelData The data formatted as expected for the underlying object


### PR DESCRIPTION
|Q|A|
|---|---|
|Branch?|master|
|Bug fix?|no|
|New feature?|yes|
|BC breaks?|no|
|Deprecations?|maybe|
|Tests pass?|yes|
|Fixed tickets| [#25738](https://github.com/symfony/symfony/issues/25738)|
|License|MIT|