### PR TITLE
Allowing plural message when extra_fields found

### DIFF
--- a/Extension/Validator/Constraints/FormValidator.php
+++ b/Extension/Validator/Constraints/FormValidator.php
@@ -148,6 +148,7 @@ class FormValidator extends ConstraintValidator
             $this->context->setConstraint($formConstraint);
             $this->context->buildViolation($config->getOption('extra_fields_message', ''))
                 ->setParameter('{{ extra_fields }}', '"'.implode('", "', array_keys($form->getExtraData())).'"')
+                ->setPlural(count($form->getExtraData()))
                 ->setInvalidValue($form->getExtraData())
                 ->setCode(Form::NO_SUCH_FIELD_ERROR)
                 ->addViolation();


### PR DESCRIPTION
When using allow_extra_fields feature (and set to false) with an extra_fields_message, this message can now support pluralization regarding count of extra fields. e.g. "Unexpected field found|Unexpected fields found"