### PR TITLE
migrate to symfony 6

### DIFF
--- a/FormErrorIterator.php
+++ b/FormErrorIterator.php
@@ -99,7 +99,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
      *
      * @return T An error or an iterator containing nested errors
      */
-    public function current(): FormError|self
+    public function current(): FormError|self|bool
     {
         return current($this->errors);
     }


### PR DESCRIPTION
fixed return value of symfony 'current' function, because php native 'current' function may return 'false' with empty array