### PR TITLE
Pass prototype_options to ResizeFormEventlistener, apply to new fields - Fix for issue 49786

### DIFF
--- a/Extension/Core/EventListener/ResizeFormListener.php
+++ b/Extension/Core/EventListener/ResizeFormListener.php
@@ -25,18 +25,20 @@ use Symfony\Component\Form\FormInterface;
 class ResizeFormListener implements EventSubscriberInterface
 {
     protected $type;
-    protected $options;
+    protected $entryOptions;
+    protected $prototypeOptions;
     protected $allowAdd;
     protected $allowDelete;
 
     private \Closure|bool $deleteEmpty;
 
-    public function __construct(string $type, array $options = [], bool $allowAdd = false, bool $allowDelete = false, bool|callable $deleteEmpty = false)
+    public function __construct(string $type, array $entryOptions = [], array $prototypeOptions = [], bool $allowAdd = false, bool $allowDelete = false, bool|callable $deleteEmpty = false)
     {
         $this->type = $type;
         $this->allowAdd = $allowAdd;
         $this->allowDelete = $allowDelete;
-        $this->options = $options;
+        $this->entryOptions = $entryOptions;
+        $this->prototypeOptions = $prototypeOptions;
         $this->deleteEmpty = \is_bool($deleteEmpty) ? $deleteEmpty : $deleteEmpty(...);
     }
 
@@ -68,7 +70,7 @@ class ResizeFormListener implements EventSubscriberInterface
         foreach ($data as $name => $value) {
             $form->add($name, $this->type, array_replace([
                 'property_path' => '['.$name.']',
-            ], $this->options));
+            ], $this->entryOptions));
         }
     }
 
@@ -96,7 +98,7 @@ class ResizeFormListener implements EventSubscriberInterface
                 if (!$form->has($name)) {
                     $form->add($name, $this->type, array_replace([
                         'property_path' => '['.$name.']',
-                    ], $this->options));
+                    ], $this->prototypeOptions));
                 }
             }
         }

--- a/Extension/Core/Type/CollectionType.php
+++ b/Extension/Core/Type/CollectionType.php
@@ -40,6 +40,7 @@ class CollectionType extends AbstractType
         $resizeListener = new ResizeFormListener(
             $options['entry_type'],
             $options['entry_options'],
+            array_replace($options['entry_options'], $options['prototype_options']),
             $options['allow_add'],
             $options['allow_delete'],
             $options['delete_empty']

--- a/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -59,7 +59,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [1 => 'string', 2 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], false, false);
+        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], [], false, false);
         $listener->preSetData($event);
 
         $this->assertFalse($this->form->has('0'));
@@ -72,7 +72,7 @@ class ResizeFormListenerTest extends TestCase
         $this->expectException(UnexpectedTypeException::class);
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->preSetData($event);
     }
 
@@ -80,7 +80,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $data = null;
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, [], false, false);
+        $listener = new ResizeFormListener(TextType::class, [], [], false, false);
         $listener->preSetData($event);
 
         $this->assertSame(0, $this->form->count());
@@ -92,7 +92,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'string', 1 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], true, false);
+        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], [], true, false);
         $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -106,7 +106,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -120,7 +120,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('0'));
@@ -133,7 +133,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'string', 2 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -145,7 +145,7 @@ class ResizeFormListenerTest extends TestCase
     {
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('1'));
@@ -157,7 +157,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = null;
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('1'));
@@ -170,7 +170,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = '';
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('1'));
@@ -182,7 +182,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'first', 1 => 'second', 2 => 'third'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->onSubmit($event);
 
         $this->assertEquals([1 => 'second'], $event->getData());
@@ -194,7 +194,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'first', 1 => 'second', 2 => 'third'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->onSubmit($event);
 
         $this->assertEquals($data, $event->getData());
@@ -205,7 +205,7 @@ class ResizeFormListenerTest extends TestCase
         $this->expectException(UnexpectedTypeException::class);
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, false);
+        $listener = new ResizeFormListener('text', [], [], false, false);
         $listener->onSubmit($event);
     }
 
@@ -215,7 +215,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = null;
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->onSubmit($event);
 
         $this->assertEquals([], $event->getData());
@@ -227,7 +227,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = new \ArrayObject([0 => 'first', 1 => 'second', 2 => 'third']);
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->onSubmit($event);
 
         $this->assertArrayNotHasKey(0, $event->getData());
@@ -240,7 +240,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = new ArrayCollection([0 => 'first', 1 => 'second', 2 => 'third']);
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true);
+        $listener = new ResizeFormListener('text', [], [], false, true);
         $listener->onSubmit($event);
 
         $this->assertArrayNotHasKey(0, $event->getData());
@@ -258,7 +258,7 @@ class ResizeFormListenerTest extends TestCase
             $this->form->get($child)->submit($dat);
         }
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener('text', [], false, true, true);
+        $listener = new ResizeFormListener('text', [], [], false, true, true);
         $listener->onSubmit($event);
 
         $this->assertEquals([0 => 'first'], $event->getData());
@@ -288,7 +288,7 @@ class ResizeFormListenerTest extends TestCase
         $callback = function ($data) {
             return null === $data['name'];
         };
-        $listener = new ResizeFormListener('text', [], false, true, $callback);
+        $listener = new ResizeFormListener('text', [], [], false, true, $callback);
         $listener->onSubmit($event);
 
         $this->assertEquals(['0' => ['name' => 'John']], $event->getData());

--- a/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -447,6 +447,29 @@ class CollectionTypeTest extends BaseTypeTestCase
         $this->assertSame('foo', $form->createView()->vars['prototype']->vars['help']);
     }
 
+    public function testPrototypeOptionsAppliedToNewFields()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, ['first'], [
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_type' => TextTypeTest::TESTED_TYPE,
+            'entry_options' => [
+                'disabled' => true,
+            ],
+            'prototype_options' => [
+                'disabled' => false,
+            ],
+        ]);
+
+        $form->submit(['first_changed', 'second']);
+
+        $this->assertTrue($form->has('0'));
+        $this->assertTrue($form->has('1'));
+        $this->assertSame('first', $form[0]->getData());
+        $this->assertSame('second', $form[1]->getData());
+        $this->assertSame(['first', 'second'], $form->getData());
+    }
+
     public function testEntriesBlockPrefixes()
     {
         $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [


### PR DESCRIPTION
Fixes the issue described here: https://github.com/symfony/symfony/issues/49786

New fields in the collection should have the prototype_options applied, so the use case described in this blog works: https://symfony.com/blog/new-in-symfony-6-1-customizable-collection-prototypes

If the entry_options are applied instead of prototype_options, the fields would be disabled and thus cannot be submitted.

Feedback welcome.