### PR TITLE
Add support for time types without seconds

### DIFF
--- a/Extension/Validator/ValidatorTypeGuesser.php
+++ b/Extension/Validator/ValidatorTypeGuesser.php
@@ -155,7 +155,12 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 return new TypeGuess(LocaleType::class, [], Guess::HIGH_CONFIDENCE);
 
             case Time::class:
-                return new TypeGuess(TimeType::class, ['input' => 'string'], Guess::HIGH_CONFIDENCE);
+                $options = ['input' => 'string'];
+                if (!$constraint->withSeconds) {
+                    $options['input_format'] = 'H:i';
+                }
+
+                return new TypeGuess(TimeType::class, $options, Guess::HIGH_CONFIDENCE);
 
             case Url::class:
                 return new TypeGuess(UrlType::class, [], Guess::HIGH_CONFIDENCE);


### PR DESCRIPTION
Previously, if you try to use this guesser with a Time field without seconds, this fails because it doesn't take the withSeconds parameter into consideration.

Now, this will add `input_format` = 'H:i' if `withoutSeconds` = true.

I cannot see where the tests are for this, so have not written one, but please advise if there is somewhere I can add one.