### PR TITLE
Refactor Form Package: Simplify array access for query and request parameters

### DIFF
--- a/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -61,7 +61,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
                     return;
                 }
 
-                $data = $request->query->all()[$name];
+                $data = $request->query->all($name);
             }
         } else {
             // Mark the form with an error if the uploaded size was too large
@@ -85,7 +85,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
                 $files = $request->files->all();
             } elseif ($request->request->has($name) || $request->files->has($name)) {
                 $default = $form->getConfig()->getCompound() ? [] : null;
-                $params = $request->request->all()[$name] ?? $default;
+                $params = $request->request->all($name) ?? $default;
                 $files = $request->files->get($name, $default);
             } else {
                 // Don't submit the form if it is not present in the request


### PR DESCRIPTION
Refactor Form Package: Simplify array access for query and request parameters

- Replaced array access on query and request parameters with direct key retrieval
- Changed `$request->query->all()[$name]` to `$request->query->all($name)`
- Changed `$request->request->all()[$name] ?? $default` to `$request->request->all($name) ?? $default`
